### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-members.yml
+++ b/.github/workflows/generate-members.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate-member-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/1](https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Based on the workflow's functionality, it appears that the script only needs to read repository contents. Therefore, we will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
