### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,5 +1,8 @@
 name: Jekyll site CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/10](https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/10)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow. Since the workflow only needs to read the repository's contents, the `contents: read` permission is sufficient.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
