### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete URL substring sanitization

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -696,12 +696,18 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         
         // 他の画像直接URLの場合はそのまま返す
-        if (url.includes('static.wikia.nocookie.net') || 
-            url.includes('.gif') || 
-            url.includes('.jpg') || 
-            url.includes('.png') ||
-            url.includes('.webp')) {
-            return url;
+        // 安全なURLのホスト判定に置き換え
+        try {
+            const parsedUrl = new URL(url);
+            if (parsedUrl.hostname === 'static.wikia.nocookie.net' || 
+                url.includes('.gif') || 
+                url.includes('.jpg') || 
+                url.includes('.png') ||
+                url.includes('.webp')) {
+                return url;
+            }
+        } catch (e) {
+            // URLパース失敗時はfall through
         }
         
         return url;


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/17](https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/17)

To properly validate that a URL is from `static.wikia.nocookie.net`, the code should **parse the URL using the `URL` constructor**, and check that its `hostname` exactly matches `static.wikia.nocookie.net` or an accepted subdomain variant (if needed). This prevents attackers from bypassing the check by placing the domain string elsewhere in the URL (such as the path, params, or within another domain name). Update the code block in `extractActualImageUrl` to use this approach, specifically changing lines 699 onward to replace the substring matching with a check based on the parsed URL’s `hostname`.

Steps:
- Parse the URL with `new URL(url)`.
- Check if the `.hostname` exactly matches `static.wikia.nocookie.net` (and perhaps also allow subdomains if that's the intention, but don’t assume unless shown).
- Only then return the URL as valid.

No new libraries are required, since the standard `URL` constructor is supported in modern browsers and Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
