### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -1121,6 +1121,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 
                 // 最終手段: 新しいタブで開く
+                // Validate protocol for security before creating download link
+                let safe = false;
+                try {
+                    const parsedUrl = new URL(url);
+                    const allowedProtocols = ['http:', 'https:', 'ftp:'];
+                    safe = allowedProtocols.includes(parsedUrl.protocol);
+                } catch (e) {
+                    safe = false;
+                }
+                if (!safe) {
+                    showStatus('ダウンロードできないURLです（許可されていないプロトコル: ' + url + '）', 'error');
+                    throw new Error('Unsafe protocol for direct download');
+                }
                 const link = document.createElement('a');
                 link.href = url;
                 link.download = filename || 'download';


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/19](https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/19)

To fix the vulnerability, sanitize and restrict which protocols/schemes may be used for the `href` attribute of the generated anchor tag. A defensive solution is to ensure only "safe" schemes are allowed (`http:`, `https:`, perhaps `ftp:` if desired), and to reject or ignore URLs starting with dangerous schemes (`javascript:`, `data:`, etc.). This can be done by parsing the URL using the `URL` constructor and checking its `protocol` before using it as `href`. The best way to fix the vulnerability is to add an explicit whitelist/protocol check before creating and using the anchor element at line 1125. Insert this check into the block before dynamically creating the link; if the URL fails, show an error message and do not create the link.

Only code within `assets/js/download.js` is to be edited. No new external libraries are required for protocol checking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
