### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -1011,7 +1011,18 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     // 手動ダウンロード用のUI表示
+    function escapeHTML(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/\//g, '&#x2F;');
+    }
+
     function showManualDownloadUI(videoId) {
+        const escapedVideoId = escapeHTML(videoId);
         const modalHtml = `
             <div id="ytDownloadModal" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); 
                 background: white; padding: 20px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); 
@@ -1023,7 +1034,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     <li>デスクトップアプリ（youtube-dl、yt-dlp）を使用する</li>
                     <li>オンラインサービスを利用する</li>
                 </ol>
-                <p>動画ID: <code>${videoId}</code></p>
+                <p>動画ID: <code>${escapedVideoId}</code></p>
                 <button onclick="document.getElementById('ytDownloadModal').remove()" 
                     style="background: #4CAF50; color: white; border: none; padding: 10px 20px; 
                     border-radius: 4px; cursor: pointer;">閉じる</button>


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/18](https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/18)

To safely include `videoId` within the modal HTML, we must ensure it is properly escaped before being used in a context where the browser interprets HTML. The ideal fix is to encode the `videoId` before it is interpolated into the HTML string, so any potentially dangerous characters are converted to harmless entities. This can be achieved by writing a helper function (e.g., `escapeHTML`) that replaces special characters (`&`, `<`, `>`, `"`, `'`, and `/`) with their corresponding HTML entities. We should apply this escaping when constructing `modalHtml`, specifically on the `${videoId}` interpolation in line 1026. To implement this, define the `escapeHTML` function within the same file and use it in `showManualDownloadUI` when inserting `videoId`. No external dependencies are needed—this is a well-known utility function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
