### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -1146,7 +1146,19 @@ document.addEventListener('DOMContentLoaded', function() {
                     throw new Error('Unsafe protocol for direct download');
                 }
                 const link = document.createElement('a');
-                link.href = url;
+                // 追加の安全プロトコルチェック (http/https のみ許可)
+                let parsedUrl;
+                try {
+                    parsedUrl = new URL(url);
+                } catch (e) {
+                    showStatus('無効なURLです。', 'error');
+                    throw new Error('Invalid URL');
+                }
+                if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+                    showStatus('許可されていないプロトコルです。', 'error');
+                    throw new Error('Disallowed protocol');
+                }
+                link.href = parsedUrl.href;
                 link.download = filename || 'download';
                 link.target = '_blank';
                 link.rel = 'noopener noreferrer';


### PR DESCRIPTION
Potential fix for [https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/19](https://github.com/Drowse-Lab/Drowse-Lab/security/code-scanning/19)

To fix the problem, all URLs accepted from user input must be strictly validated before assigning them to potentially dangerous properties such as `link.href`. The best way is to ensure that:

1. The URL is a string, strictly parses as a standard URL, and only allows certain safe protocols (typically `http:` and `https:`).
2. Disallow or filter URLs with potentially dangerous schemes such as `javascript:`, `data:`, and others.
3. Where possible, use URL parsing (`new URL(url)`) to vet the protocol rather than relying on regex.

The region to edit is in the block around line 1149, ensuring that before setting `link.href = url;`, the URL is strictly validated/filtered. If a safe check with the variable `safe` already occurs, ensure this check *absolutely* prohibits all unsafe protocols. If not, explicitly filter out evil protocols right before the assignment. You may also want to consider encoding or even forcing a download via Blob URLs, but the main fix is honestly vetting the protocol.

Additionally, for extra defense, explicitly set the `download` attribute only with a sanitized filename.

**Changes required**:

- Before `link.href = url;` at line 1149, double-check and enforce that `url` is only `http:` or `https:`.
- Ideally, move the full protocol check into this region if it is not already sufficient, using `try { parsed = new URL(url); ... }` and immediately returning or erroring out if the protocol is unsafe.
- No external libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
